### PR TITLE
fix: disable system tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,39 +92,39 @@ jobs:
           # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test
-
-  system-test:
-    runs-on: ubuntu-latest
-
-    # services:
-    #  redis:
-    #    image: valkey/valkey:8
-    #    ports:
-    #      - 6379:6379
-    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
-    steps:
-      - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Run System Tests
-        env:
-          RAILS_ENV: test
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test:system
-
-      - name: Keep screenshots from failed system tests
-        uses: actions/upload-artifact@v7
-        if: failure()
-        with:
-          name: screenshots
-          path: ${{ github.workspace }}/tmp/screenshots
-          if-no-files-found: ignore
+# TODO: Re-enable this once a system test exists. Currently this fails because the system test files haven't been generated yet.
+#  system-test:
+#    runs-on: ubuntu-latest
+#
+#    # services:
+#    #  redis:
+#    #    image: valkey/valkey:8
+#    #    ports:
+#    #      - 6379:6379
+#    #    options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+#    steps:
+#      - name: Install packages
+#        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips
+#
+#      - name: Checkout code
+#        uses: actions/checkout@v6
+#
+#      - name: Set up Ruby
+#        uses: ruby/setup-ruby@v1
+#        with:
+#          bundler-cache: true
+#
+#      - name: Run System Tests
+#        env:
+#          RAILS_ENV: test
+#          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+#          # REDIS_URL: redis://localhost:6379/0
+#        run: bin/rails db:test:prepare test:system
+#
+#      - name: Keep screenshots from failed system tests
+#        uses: actions/upload-artifact@v7
+#        if: failure()
+#        with:
+#          name: screenshots
+#          path: ${{ github.workspace }}/tmp/screenshots
+#          if-no-files-found: ignore


### PR DESCRIPTION
System tests blow up CI because rails no longer generates the default files to make this command work until you actually create a system test for the first time