### PR TITLE
Feat: Add classrooms and Rosters

### DIFF
--- a/app/controllers/classroom_rosters_controller.rb
+++ b/app/controllers/classroom_rosters_controller.rb
@@ -1,0 +1,7 @@
+class ClassroomRostersController < ApplicationController
+  allow_unauthenticated_access
+
+  def show
+    @classroom = Classroom.includes(:students).find_by!(uuid: params.expect(:uuid))
+  end
+end

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -1,5 +1,6 @@
 class ClassroomsController < ApplicationController
   before_action :set_classroom, only: %i[ edit update ]
+
   # GET /classrooms/1/edit
   def edit
   end

--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -1,0 +1,29 @@
+class ClassroomsController < ApplicationController
+  before_action :set_classroom, only: %i[ edit update ]
+  # GET /classrooms/1/edit
+  def edit
+  end
+  # PATCH/PUT /classrooms/1 or /classrooms/1.json
+  def update
+    respond_to do |format|
+      if @classroom.update(classroom_params)
+        format.html { redirect_to school_students_url(@classroom.school), notice: "Classroom was successfully updated.", status: :see_other }
+        format.json { render :show, status: :ok, location: @classroom }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @classroom.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_classroom
+      @classroom = Classroom.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def classroom_params
+      params.expect(classroom: [ :name, :teacher ])
+    end
+end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -4,7 +4,7 @@ class StudentsController < ApplicationController
 
   # GET /students or /students.json
   def index
-    @students = @school.students.all
+    @students = @school.students.includes(:classroom).all
   end
 
   # GET /students/1 or /students/1.json
@@ -18,6 +18,7 @@ class StudentsController < ApplicationController
 
   # GET /students/1/edit
   def edit
+    @classrooms = @student.school.classrooms.all
   end
 
   # POST /students or /students.json
@@ -70,6 +71,6 @@ class StudentsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def student_params
-      params.expect(student: [ :first_name, :last_name, :email, :grade_level, :gender ])
+      params.expect(student: [ :first_name, :last_name, :email, :grade_level, :gender, :classroom_id ])
     end
 end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -1,2 +1,0 @@
-module SchoolsHelper
-end

--- a/app/models/classroom.rb
+++ b/app/models/classroom.rb
@@ -1,0 +1,4 @@
+class Classroom < ApplicationRecord
+  belongs_to :school
+  has_many :students
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,4 +1,5 @@
 class School < ApplicationRecord
   has_many :students, dependent: :destroy
+  has_many :classrooms, dependent: :destroy
   validates :name, presence: true
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -5,4 +5,6 @@ class Student < ApplicationRecord
   enum :gender, %i[male female other].index_by(&:itself)
 
   validates :first_name, :last_name, :grade_level, presence: true
+
+  def full_name = [ first_name, last_name ].join(" ")
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,5 +1,6 @@
 class Student < ApplicationRecord
   belongs_to :school
+  belongs_to :classroom
 
   enum :gender, %i[male female other].index_by(&:itself)
 

--- a/app/views/classroom_rosters/show.html.erb
+++ b/app/views/classroom_rosters/show.html.erb
@@ -1,0 +1,14 @@
+<header class="flex items-center justify-between mb-8">
+  <h1 class="text-4xl"><%= @classroom.name %></h1>
+</header>
+<ul class="list bg-base-100 rounded-box shadow-md">
+  <% @classroom.students.sort_by(&:full_name).each do |student| %>
+      <%= link_to "#" do %>
+      <li class="list-row link link-hover">
+        <span class="text-2xl">
+          <%= student.full_name %>
+        </span>
+      </li>
+      <% end %>
+  <% end %>
+</ul>

--- a/app/views/classrooms/_classroom.html.erb
+++ b/app/views/classrooms/_classroom.html.erb
@@ -1,0 +1,14 @@
+<div id="<%= dom_id classroom %>" class="w-full sm:w-auto my-5 space-y-5">
+  <div>
+    <strong class="block font-medium mb-1">Name:</strong>
+    <%= classroom.name %>
+  </div>
+  <div>
+    <strong class="block font-medium mb-1">School:</strong>
+    <%= classroom.school_id %>
+  </div>
+  <div>
+    <strong class="block font-medium mb-1">Teacher:</strong>
+    <%= classroom.teacher %>
+  </div>
+</div>

--- a/app/views/classrooms/_form.html.erb
+++ b/app/views/classrooms/_form.html.erb
@@ -19,7 +19,7 @@
     <%= form.text_field :teacher, class: "input w-full" %>
 
     <%= form.label :Link, class: "label" %>
-    <a href="https://www.classroom.google.com/" target="_blank" class="link">https://www.classroom.google.com/</a>
+    <%= link_to classroom_roster_url(classroom.uuid), classroom_roster_path(classroom.uuid), class: 'link' %>
 
     <%= form.submit class: "btn btn-primary" %>
   </div>

--- a/app/views/classrooms/_form.html.erb
+++ b/app/views/classrooms/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with(model: classroom) do |form| %>
+  <div class="flex flex-col gap-2">
+  <% if classroom.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(classroom.errors.count, "error") %> prohibited this classroom from being saved:</h2>
+
+      <ul>
+        <% classroom.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+    <%= form.label :name, class: "label" %>
+    <%= form.text_field :name, class: "input w-full" %>
+
+    <%= form.label :teacher, class: "label" %>
+    <%= form.text_field :teacher, class: "input w-full" %>
+
+    <%= form.label :Link, class: "label" %>
+    <a href="https://www.classroom.google.com/" target="_blank" class="link">https://www.classroom.google.com/</a>
+
+    <%= form.submit class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/classrooms/edit.html.erb
+++ b/app/views/classrooms/edit.html.erb
@@ -1,16 +1,16 @@
-<% content_for :title, "Editing student" %>
+<% content_for :title, "Editing classroom" %>
 <nav class="breadcrumbs text-sm">
   <ul>
     <li><%= link_to "All Schools", schools_path %></li>
-    <li><%= link_to @student.school.name, school_students_path(@student.school) %></li>
-    <li>Edit Student</li>
+    <li><%= link_to @classroom.school.name, school_path(@classroom.school) %></li>
+    <li>Edit Classroom</li>
   </ul>
 </nav>
 <section class="py-10 flex items-center justify-center">
   <div class="card card-border bg-base-100 shadow-md w-96">
     <div class="card-body">
-      <h1 class="card-title">Editing Student</h1>
-      <%= render "form", student: @student, classrooms: @classrooms %>
+      <h1 class="card-title">Editing Classroom</h1>
+      <%= render "form", classroom: @classroom %>
     </div>
   </div>
 </section>

--- a/app/views/classrooms/index.html.erb
+++ b/app/views/classrooms/index.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, "Classrooms" %>
+
+<div class="w-full">
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-md inline-block" id="notice"><%= notice %></p>
+  <% end %>
+
+  <div class="flex justify-between items-center">
+    <h1 class="font-bold text-4xl">Classrooms</h1>
+    <%= link_to "New classroom", new_classroom_path, class: "rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white block font-medium" %>
+  </div>
+
+  <div id="classrooms" class="min-w-full divide-y divide-gray-200 space-y-5">
+    <% if @classrooms.any? %>
+      <% @classrooms.each do |classroom| %>
+        <div class="flex flex-col sm:flex-row justify-between items-center pb-5 sm:pb-0">
+          <%= render classroom %>
+          <div class="w-full sm:w-auto flex flex-col sm:flex-row space-x-2 space-y-2">
+            <%= link_to "Show", classroom, class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <%= link_to "Edit", edit_classroom_path(classroom), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-gray-100 hover:bg-gray-50 inline-block font-medium" %>
+            <%= button_to "Destroy", classroom, method: :delete, class: "w-full sm:w-auto rounded-md px-3.5 py-2.5 text-white bg-red-600 hover:bg-red-500 font-medium cursor-pointer", data: { turbo_confirm: "Are you sure?" } %>
+          </div>
+        </div>
+      <% end %>
+    <% else %>
+      <p class="text-center my-10">No classrooms found.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/students/_form.html.erb
+++ b/app/views/students/_form.html.erb
@@ -27,6 +27,8 @@
     <%= form.label :gender, class: "label" %>
     <%= form.text_field :gender, class: "input w-full" %>
 
+    <%= form.collection_select :classroom_id, classrooms, :id, :name, { include_blank: "Select a classroom" }, class: "select w-full" %>
+
     <%= form.submit class: "btn btn-primary" %>
   </div>
 <% end %>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -23,6 +23,7 @@
     <th>Email</th>
     <th>Grade level</th>
     <th>Gender</th>
+    <th>Classroom</th>
     <th>Actions</th>
   </tr>
   </thead>
@@ -34,6 +35,7 @@
       <td><%= student.email %></td>
       <td><%= student.grade_level %></td>
       <td><%= student.gender %></td>
+      <td><%= link_to student.classroom.name, edit_classroom_path(student.classroom), class: "btn btn-link" %></td>
       <td>
         <div class="flex gap-2">
           <%= link_to "Edit", edit_student_path(student), class: "btn btn-primary" %>

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -11,7 +11,7 @@
   <div class="card card-border bg-base-100 shadow-md w-96">
     <div class="card-body">
       <h1 class="card-title">New Student</h1>
-      <%= render "form", student: @student %>
+      <%= render "form", student: @student, classrooms: @school.classrooms %>
     </div>
   </div>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   scope :admin do
     resources :schools do
       resources :students, shallow: true
+      resources :classrooms, shallow: true, only: %i[edit update]
     end
   end
   root to: "schools#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
+  get "classroom_rosters/show"
   resource :session
   resources :passwords, param: :token
+  resources :classroom_rosters, only: %i[show], param: :uuid
   scope :admin do
     resources :schools do
       resources :students, shallow: true

--- a/db/migrate/20260428233313_create_classrooms.rb
+++ b/db/migrate/20260428233313_create_classrooms.rb
@@ -1,0 +1,16 @@
+class CreateClassrooms < ActiveRecord::Migration[8.1]
+  def change
+    create_table :classrooms do |t|
+      t.string :name
+      t.belongs_to :school, null: false, foreign_key: true
+      t.string :teacher
+      t.string :uuid, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+
+    change_table :students do |t|
+      t.belongs_to :classroom, null: false, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_234927) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_28_233313) do
+  create_table "classrooms", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name"
+    t.integer "school_id", null: false
+    t.string "teacher"
+    t.datetime "updated_at", null: false
+    t.string "uuid", null: false
+    t.index ["school_id"], name: "index_classrooms_on_school_id"
+    t.index ["uuid"], name: "index_classrooms_on_uuid", unique: true
+  end
+
   create_table "schools", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "name"
@@ -27,6 +38,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_234927) do
   end
 
   create_table "students", force: :cascade do |t|
+    t.integer "classroom_id", null: false
     t.datetime "created_at", null: false
     t.string "email"
     t.string "first_name", null: false
@@ -35,6 +47,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_234927) do
     t.string "last_name", null: false
     t.integer "school_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["classroom_id"], name: "index_students_on_classroom_id"
     t.index ["school_id"], name: "index_students_on_school_id"
   end
 
@@ -47,6 +60,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_234927) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "classrooms", "schools"
   add_foreign_key "sessions", "users"
+  add_foreign_key "students", "classrooms"
   add_foreign_key "students", "schools"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,6 +25,9 @@ end
 # randomly sample 3 grade levels and create 10 students for each grade level
 grades = (1..12).to_a.sample(3)
 grades.each do |grade|
-  students = 10.times.map { build_student_attrs(grade_level: grade) }
+  classrooms = 2.times.map do |i|
+    school.classrooms.create!(name: "Classroom #{ i + 1 }", teacher: maybe { Faker::Name.name }, uuid: SecureRandom.urlsafe_base64(32))
+  end
+  students = 10.times.map { |i| build_student_attrs(grade_level: grade, classroom_id: classrooms[i % 2].id) }
   school.students.create!(students)
 end

--- a/test/controllers/classroom_rosters_controller_test.rb
+++ b/test/controllers/classroom_rosters_controller_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class ClassroomRostersControllerTest < ActionDispatch::IntegrationTest
+  test "should get show without signing in" do
+    classroom = classrooms(:one)
+    get classroom_roster_url(classroom.uuid)
+    assert_response :success
+  end
+end

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ClassroomsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @classroom = classrooms(:one)
+    sign_in_as users(:admin)
+  end
+
+  test "should get edit" do
+    get edit_classroom_url(@classroom)
+    assert_response :success
+  end
+
+  test "should update classroom" do
+    patch classroom_url(@classroom), params: { classroom: { name: @classroom.name, teacher: @classroom.teacher } }
+    assert_redirected_to school_students_url(@classroom.school)
+  end
+end

--- a/test/controllers/classrooms_controller_test.rb
+++ b/test/controllers/classrooms_controller_test.rb
@@ -12,6 +12,7 @@ class ClassroomsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update classroom" do
+    sign_in_as users(:admin)
     patch classroom_url(@classroom), params: { classroom: { name: @classroom.name, teacher: @classroom.teacher } }
     assert_redirected_to school_students_url(@classroom.school)
   end

--- a/test/controllers/students_controller_test.rb
+++ b/test/controllers/students_controller_test.rb
@@ -19,7 +19,7 @@ class StudentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create student" do
     assert_difference("Student.count") do
-      post school_students_url(@school), params: { student: { email: @student.email, first_name: @student.first_name, gender: @student.gender, grade_level: @student.grade_level, last_name: @student.last_name, school_id: @student.school_id } }
+      post school_students_url(@school), params: { student: { email: @student.email, first_name: @student.first_name, gender: @student.gender, grade_level: @student.grade_level, last_name: @student.last_name, classroom_id: @student.classroom_id } }
     end
 
     assert_redirected_to student_url(Student.last)
@@ -38,6 +38,15 @@ class StudentsControllerTest < ActionDispatch::IntegrationTest
   test "should update student" do
     patch student_url(@student), params: { student: { email: @student.email, first_name: @student.first_name, gender: @student.gender, grade_level: @student.grade_level, last_name: @student.last_name, school_id: @student.school_id } }
     assert_redirected_to student_url(@student)
+  end
+
+  test "can update a student's classroom" do
+    classroom = @student.classroom.dup
+    classroom.update! uuid: SecureRandom.urlsafe_base64(32), name: "New Classroom"
+    assert_changes -> { @student.reload.classroom_id } do
+      patch student_url(@student), params: { student: { classroom_id: classroom.id } }
+      assert_redirected_to student_url(@student)
+    end
   end
 
   test "should destroy student" do

--- a/test/fixtures/classrooms.yml
+++ b/test/fixtures/classrooms.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: Classroom 1
+  school: one
+  teacher: Teacher 1
+  uuid: abcd-1234-efgh-5678
+
+two:
+  name: Classroom 2
+  school: two
+  teacher:
+  uuid: wxyz-9876-ijkl-5432

--- a/test/fixtures/students.yml
+++ b/test/fixtures/students.yml
@@ -5,6 +5,7 @@ ada:
   grade_level: 5
   gender:
   school: one
+  classroom: one
 
 grace:
   first_name: Grace
@@ -13,3 +14,4 @@ grace:
   grade_level: 6
   gender: female
   school: two
+  classroom: two

--- a/test/models/classroom_test.rb
+++ b/test/models/classroom_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ClassroomTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
- Adds classrooms to students
- Adds a "classroom roster" page that shows the list of students for them to click to login

# Why
- I am not sure about the classroom ui flow so I'm skipping it for now. You have to pick a classroom for a student. Currently there's no way to create a classroom, you just assign from an existing list. You can edit a classroom by clicking the classroom name on the student index view
- Note the roster doesn't currently actually do the sign in yet (all dummy links), that will be coming next.