### PR TITLE
Fix: Seeds should generate modules

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,7 +42,8 @@ grades.each do |grade|
     classroom = school.classrooms.create!(name: "Classroom #{ i + 1 }", teacher: maybe { Faker::Name.name }, uuid: SecureRandom.urlsafe_base64(32))
     assigned = Faker::Boolean.boolean ? [ programs.sample ] : programs
     assigned.each do |program|
-      classroom.classroom_programs.create!(program: program, level: %w[basic moderate advanced].sample)
+      classroom_program = classroom.classroom_programs.create!(program: program, level: %w[basic moderate advanced].sample)
+      classroom_program.generate_modules!
     end
     classroom
   end


### PR DESCRIPTION
# What
- Updates the seeds to ensure modules are generated for the seeded classrooms. This is needed due to the choice that the generation is an explicit method rather than a callback. 