### PR TITLE
Add herb dev server to Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bin/rails server
 css: bin/rails tailwindcss:watch
+herb: bundle exec herb dev


### PR DESCRIPTION
### Description
 
The [herb dev server](https://herb-tools.dev/projects/dev-server) is easy to run, this PR adds a Procfile.dev entry to start it up so we can get the green light in dev

<img width="302" height="149" alt="image" src="https://github.com/user-attachments/assets/863e2cdd-1c29-48ca-bd66-3d6ff81b2e91" />

