### PR TITLE
Fix: Remove default scopes

### DIFF
--- a/app/controllers/content_modules_controller.rb
+++ b/app/controllers/content_modules_controller.rb
@@ -5,7 +5,7 @@ class ContentModulesController < AdminController
     @programs = Program.order(:name)
     @active_program = @programs.find { |p| p.id.to_s == params[:program_id] } || @programs.first
     @modules_by_level = @active_program
-      .content_modules
+      .content_modules.ordered
       .includes(:links)
       .group_by(&:level)
   end

--- a/app/models/concerns/ordered.rb
+++ b/app/models/concerns/ordered.rb
@@ -1,0 +1,7 @@
+module Ordered
+  extend ActiveSupport::Concern
+
+  included do
+    scope :ordered, -> { order(:position) }
+  end
+end

--- a/app/models/content_module.rb
+++ b/app/models/content_module.rb
@@ -1,11 +1,11 @@
 class ContentModule < ApplicationRecord
+  include Ordered
+
   belongs_to :program
-  has_many :links, dependent: :destroy
+  has_many :links, -> { ordered }, dependent: :destroy
   has_many :classroom_modules, dependent: :restrict_with_error
 
   enum :level, { basic: "basic", moderate: "moderate", advanced: "advanced" }, validate: true
 
   validates :name, :level, presence: true
-
-  default_scope { order(:position) }
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -7,5 +7,4 @@ class Link < ApplicationRecord
 
   validates :title, :url, :link_type, presence: true
   validates :url, format: { with: /\Ahttps?:\/\/.+\z/i, message: "must start with http:// or https://" }, allow_blank: true
-
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,4 +1,6 @@
 class Link < ApplicationRecord
+  include Ordered
+
   belongs_to :content_module
 
   enum :link_type, { survey: "survey", game: "game" }, validate: true
@@ -6,5 +8,4 @@ class Link < ApplicationRecord
   validates :title, :url, :link_type, presence: true
   validates :url, format: { with: /\Ahttps?:\/\/.+\z/i, message: "must start with http:// or https://" }, allow_blank: true
 
-  default_scope { order(:position) }
 end

--- a/test/controllers/content_modules_controller_test.rb
+++ b/test/controllers/content_modules_controller_test.rb
@@ -45,6 +45,17 @@ class ContentModulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "edit lists links ordered by position" do
+    @content_module.links.destroy_all
+    @content_module.links.create!(title: "Last Link", url: "https://example.com/2", link_type: "survey", position: 2)
+    @content_module.links.create!(title: "First Link", url: "https://example.com/1", link_type: "survey", position: 1)
+
+    get edit_content_module_url(@content_module)
+
+    hrefs = css_select("table tbody tr td:first-child a").map { |link| link["href"] }
+    assert_equal [ "https://example.com/1", "https://example.com/2" ], hrefs
+  end
+
   test "should update content module" do
     patch content_module_url(@content_module), params: {
       content_module: { name: "Updated Name" }

--- a/test/models/content_module_test.rb
+++ b/test/models/content_module_test.rb
@@ -35,14 +35,6 @@ class ContentModuleTest < ActiveSupport::TestCase
     end
   end
 
-  test "links are returned in position order" do
-    content_module = ContentModule.create!(program: @program, level: "basic", name: "Ordered Module")
-    last = content_module.links.create!(title: "Last", url: "https://example.com/2", link_type: "survey", position: 2)
-    first = content_module.links.create!(title: "First", url: "https://example.com/1", link_type: "survey", position: 1)
-
-    assert_equal [ first, last ], content_module.links.to_a
-  end
-
   test "cannot be destroyed when classroom modules exist" do
     content_module = ContentModule.create!(program: @program, level: "basic", name: "Assigned Module")
     classroom_program = classroom_programs(:one)

--- a/test/models/content_module_test.rb
+++ b/test/models/content_module_test.rb
@@ -35,6 +35,14 @@ class ContentModuleTest < ActiveSupport::TestCase
     end
   end
 
+  test "links are returned in position order" do
+    content_module = ContentModule.create!(program: @program, level: "basic", name: "Ordered Module")
+    last = content_module.links.create!(title: "Last", url: "https://example.com/2", link_type: "survey", position: 2)
+    first = content_module.links.create!(title: "First", url: "https://example.com/1", link_type: "survey", position: 1)
+
+    assert_equal [ first, last ], content_module.links.to_a
+  end
+
   test "cannot be destroyed when classroom modules exist" do
     content_module = ContentModule.create!(program: @program, level: "basic", name: "Assigned Module")
     classroom_program = classroom_programs(:one)


### PR DESCRIPTION
# What
- Remove the default scopes applied to models with ordering in favor of an explicit scope
- Adds a test to assert that the content modules are ordering their links correctly