### PR TITLE
Add recommended extensions while ignoring local .vscode/settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@
 !/app/assets/builds/.keep
 
 node_modules/
+
+# editor settings and extension recommendations
+/.vscode/*
+!/.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "marcoroth.herb-lsp",
+    "Shopify.ruby-extensions-pack",
+  ]
+}


### PR DESCRIPTION
I update my .vscode/settings.json file per-project (color themes!), but it's handy to keep a recommended extensions list for new contributors that use VSCode.